### PR TITLE
ceate back botton

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,6 +85,7 @@
  }
 }
 
+.btn-light,
 .btn-danger,
 .btn-success{
  border-bottom: 3px solid gray;

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -73,6 +73,14 @@
 
 // 投稿詳細ページ
 .posts-show{
+ .back{
+  color: white;
+  font-size: 30px;
+  text-decoration: none;
+  &:hover{
+   color: red;
+  }
+ }
  .posts-show-box{
    background-color: $posts_show_box;
    border-radius: 10px;
@@ -116,6 +124,9 @@
     .score-list{
      margin: 15px;
     }
+   }
+   .heart{
+    text-decoration: none;
    }
    .btn-info,.btn-danger{
     transition: all 1s ease 0;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -39,6 +39,9 @@
   .profile-title{
    border-bottom: 1px solid;
   }
+  .edit-link{
+   border-bottom: 1px solid;
+  }
   .user-image-name{
    img{
     border-radius: 50px;

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@ class NotificationsController < ApplicationController
   before_action :ensure_user
 
   def index
-    @notifications = Notification.where(receiver_id: params[:user_id], check: false)
+    @notifications = Notification.where(receiver_id: params[:user_id], check: false).includes(:sender)
   end
 
   def destroy_all

--- a/app/views/favorites/_favorite_btn.html.erb
+++ b/app/views/favorites/_favorite_btn.html.erb
@@ -1,8 +1,8 @@
 <div class='favorite-btn'>
   <% if post.favorite_by?(current_user) %>
-    <%= link_to '❤️', post_favorites_path(post), method: :delete, remote: true %>
+    <%= link_to '❤️', post_favorites_path(post), method: :delete, remote: true, class: 'heart' %>
   <% else %>
-    <%= link_to '💙️', post_favorites_path(post), remote: true %>
+    <%= link_to '💙️', post_favorites_path(post), remote: true, class: 'heart' %>
   <% end %>
 </div>
 <div class='favorite-count'>

--- a/app/views/post_comments/_comment_field.html.erb
+++ b/app/views/post_comments/_comment_field.html.erb
@@ -4,7 +4,7 @@
     <div class='d-flex justify-content-end my-2 my-comment'>
       <!--コメント-->
       <div class='offset-1 text-break p-1 comment'>
-        <%= comment.comment %>
+        <%= safe_join(comment.comment.split("\n"), tag(:br)) %>
       </div>
       <!--アカウント画像-->
       <div class='col-2 col-md-1 p-0 pl-1 account-image'>
@@ -28,7 +28,7 @@
       </div>
       <!--コメント-->
       <div class='text-break p-1 comment'>
-        <%= comment.comment %>
+        <%= safe_join(comment.comment.split("\n"), tag(:br)) %>
       </div>
     </div>
   <% end %>

--- a/app/views/posts/_detail.html.erb
+++ b/app/views/posts/_detail.html.erb
@@ -8,7 +8,7 @@
       <!--感想-->
       <div class='form-inline d-flex align-items-start mb-4 impression-field'>
         <p class='col-4 col-sm-3 mb-1 impression-label'><%= t '.impression' %></p>
-        <p class='col-12 col-sm-9 p-1 posts-body-box'><%= post.body %></p>
+        <p class='col-12 col-sm-9 p-1 posts-body-box'><%= safe_join(post.body.split("\n"), tag(:br)) %></p>
       </div>
       <!--評価-->
       <div class='form-inline d-flex align-items-start mb-4'>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -33,8 +33,10 @@
 
         <!--ボタン-->
         <div class='d-flex justify-content-center mb-4'>
-          <%= f.submit (t '.delete'), type: 'reset', class: 'offset-1 offset-sm-2 mr-3 btn btn-danger' %>
-          <%= f.submit (t '.post'), class: 'text-center btn btn-success' %>
+          <%= link_to :back, class: 'col-3 mr-3 btn btn-light' do %>
+            <div><%= t ('.cancel') %></div>
+          <% end %>
+          <%= f.submit (t '.edit'), class: 'text-center btn btn-success' %>
         </div>
       </div>
     </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -30,7 +30,9 @@
 
         <!--ボタン-->
         <div class='d-flex justify-content-center mb-4'>
-          <%= f.submit (t '.delete'), type: 'reset', class: 'offset-1 offset-sm-2 mr-3 btn btn-danger' %>
+          <%= link_to :back, class: 'col-3 mr-3 btn btn-light' do %>
+            <div><%= t ('.cancel') %></div>
+          <% end %>
           <%= f.submit (t '.post'), class: 'text-center btn btn-success' %>
         </div>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,8 @@
 <div class='container posts-show'>
   <%= render 'shared/error', model: @post_comment %>
-  <div class='row my-5 mx-1 posts-show-box'>
+    <%= link_to '←', :back, class: 'back'  %>
+  <div class='row mt-1 mb-5 mx-1 posts-show-box'>
+    <!--ゲームタイトル-->
     <div class='col-12 d-flex align-items-center justify-content-center post-show-heading'>
       <h2 class='mb-0 text-center'>
         <%= @post.title %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,12 +14,6 @@
             <div class='d-flex align-items-center mr-4 welcom'>
               <span class='pl-3 mb-0' ></span><%= t '.welcom', user_name: current_user.name %></span>
             </div>
-            <!--マイページリンク-->
-            <li class='nav-list mr-4'>
-              <%= link_to edit_user_path(current_user.id), class: 'nav-link' do %>
-                <span class='pl-3 mb-0 nav-link-word'><%= t '.my_page'%></span>
-              <% end %>
-            </li>
             <!--通知-->
             <li class='nav-list mr-4'>
               <%= link_to user_notifications_path(current_user.id), class: 'nav-link' do %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,7 +26,9 @@
 
       <!--記録作成ボタン-->
       <div class='d-flex justify-content-center mb-2'>
-        <%= f.submit '書いた内容を消す', type: 'reset', class: 'mr-3 btn btn-danger' %>
+        <%= link_to :back, class: 'col-4 mr-3 btn btn-light' do %>
+          <div><%= t ('.cancel') %></div>
+        <% end %>
         <%= f.submit (t '.edit'), class: 'btn btn-success' %>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,25 +1,35 @@
 <div class='container users-show'>
   <div class='row mb-5'>
     <div class='col-12 col-sm-8 mt-3 '>
+      <!--プロフィール-->
       <div class='col-12 d-flex flex-wrap profile'>
-        <div class='col-12 profile-title'>
+        <div class='col-9 profile-title'>
          <h5 class='mb-0'>
            <strong><%= t '.profile_title' %></strong>
           </h5>
         </div>
+        <!--プロフィール編集へのリンク-->
+        <div class='col-3 text-right edit-link'>
+          <% if @user == current_user %>
+            <%= link_to (t '.edit'), edit_user_path(current_user.id) %>
+          <% end %>
+        </div>
+        <!--プロフィール画像とユーザー名-->
         <div class='col-12 col-sm-4 my-2 text-center user-image-name'>
           <%= attachment_image_tag @user, :profile_image, format: 'jpeg', fallback: 'no_image.jpg', size: '70x70' %>
           <div class='user-name'>
             <%= @user.name %>
           </div>
         </div>
+        <!--イントロダクション-->
         <div class='col-12 col-sm-8 my-2 px-0 user-introduction-field'>
           <div class='p-2 text-break introduction'>
-            <%= @user.introduction %>
+            <%= safe_join(@user.introduction.split("\n"), tag(:br)) %>
           </div>
         </div>
       </div>
     </div>
+    <!--検索要素-->
     <div class='col-7 offset-5 col-sm-3 offset-sm-1 my-2 sort-serach'>
       <%= render 'shared/sort_search', user: @user %>
     </div>

--- a/config/locales/views/controller/ja.yml
+++ b/config/locales/views/controller/ja.yml
@@ -2,7 +2,7 @@ ja:
   posts:
     new:
       heading: '新しい記録'
-      delete: '内容を消す'
+      cancel: 'キャンセル'
       post: '記録する'
       score: '評価'
       genre_select: 'ジャンルを選択してください'
@@ -14,8 +14,8 @@ ja:
       posted_date: '投稿日：'
     edit:
       heading: '記録の編集'
-      delete: '変更内容を削除'
-      post: '記録する'
+      cancel: 'キャンセル'
+      edit: '更新する'
       score: '評価'
     score_new:
       total_score: '総合評価'
@@ -52,11 +52,13 @@ ja:
   users:
     show:
       profile_title: 'プロフィール'
+      edit: '編集'
       my_no_posts: '画面上部の「新しく記録する」からあなたがプレイしたゲームを記録しましょう！！'
       othger_user_no_posts: '記録がありません'
     edit:
       profile: 'プロフィール'
-      edit: '変更する'
+      cancel: 'キャンセル'
+      edit: '更新する'
       caution: '※ゲストユーザーは編集ができません'
   notifications:
     index:


### PR DESCRIPTION
### キャンセルボタンを作りました
- 新規投稿、投稿編集、ユーザー編集ページの内容を消すボタンをなくし、キャンセルボタンにしました。
- キャンセルボタンを押すと、ひとつ前に表示していたページに遷移します。
- ひとつ前に表示していたページに遷移する←を作りました。

### ヘッダーからユーザー編集画面へのリンクを削除しました。
- 代わりにユーザー詳細画面のプロフィール欄にリンクを移しました。